### PR TITLE
fix: set UIView1 constrains and add to view

### DIFF
--- a/Unit3_Project/QuestionViewController.swift
+++ b/Unit3_Project/QuestionViewController.swift
@@ -104,6 +104,13 @@ class QuestionViewController: UIViewController {
     func setupSingleViewStack() {
         
         view.addSubview(UIView1)
+
+        UIView1.translatesAutoresizingMaskIntoConstraints = false
+        UIView1.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        UIView1.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+        UIView1.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        UIView1.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+
         
         let stack = UIStackView(arrangedSubviews: setupSingleButtons())
         stack.alignment = .center
@@ -111,7 +118,7 @@ class QuestionViewController: UIViewController {
         stack.spacing = 10
         stack.distribution = .fillEqually
         UIView1.addSubview(stack)
-        view.addSubview(stack)
+        view.addSubview(UIView1)
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         stack.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true


### PR DESCRIPTION
I figured out the reason.

The main reason is, to enable "UIView1.isHidden", 
you have to create valid UIView.

To realize this, you also have to set size of UIView and add to "view" as subview.
The simple way is set UIView constrains, which matches to view.
In addition, add UIView to view as subview.

Through this, xcode recognize UIView as valid view and you can use isHidden!